### PR TITLE
Fixed issues when compiling with clang

### DIFF
--- a/drivers/input/touchscreen/focaltech_touch/focaltech_ex_fun.c
+++ b/drivers/input/touchscreen/focaltech_touch/focaltech_ex_fun.c
@@ -145,7 +145,7 @@ static ssize_t fts_debug_write(struct file *filp, const char __user *buff, size_
 		break;
 
 	case PROC_HW_RESET:
-		snprintf(tmp, PAGE_SIZE, "%s", writebuf + 1);
+		snprintf(tmp, sizeof(tmp), "%s", writebuf + 1);
 		tmp[buflen - 1] = '\0';
 		if (strncmp(tmp, "focal_driver", 12) == 0) {
 			FTS_INFO("APK execute HW Reset");
@@ -815,7 +815,7 @@ static ssize_t fts_fwupgradebin_store(struct device *dev, struct device_attribut
 		return -EINVAL;
 	}
 	memset(fwname, 0, sizeof(fwname));
-	snprintf(fwname, PAGE_SIZE, "%s", buf);
+	snprintf(fwname, sizeof(fwname), "%s", buf);
 	fwname[count - 1] = '\0';
 
 	FTS_INFO("upgrade with bin file through sysfs node");
@@ -858,7 +858,7 @@ static ssize_t fts_fwforceupg_store(struct device *dev, struct device_attribute 
 		return -EINVAL;
 	}
 	memset(fwname, 0, sizeof(fwname));
-	snprintf(fwname, PAGE_SIZE, "%s", buf);
+	snprintf(fwname, sizeof(fwname), "%s", buf);
 	fwname[count - 1] = '\0';
 
 	FTS_INFO("force upgrade through sysfs node");

--- a/drivers/input/touchscreen/nt36xxx/nt36xxx_mp_ctrlram.c
+++ b/drivers/input/touchscreen/nt36xxx/nt36xxx_mp_ctrlram.c
@@ -1290,7 +1290,7 @@ static int32_t nvt_selftest_open(struct inode *inode, struct file *file)
 		 * Ex. nvt_pid = 500A
 		 *     mpcriteria = "novatek-mp-criteria-500A"
 		 */
-		snprintf(mpcriteria, PAGE_SIZE, "novatek-mp-criteria-%04X", ts->nvt_pid);
+		snprintf(mpcriteria, sizeof(mpcriteria), "novatek-mp-criteria-%04X", ts->nvt_pid);
 
 		nvt_mp_parse_dt(np, mpcriteria);
 	} else {

--- a/drivers/thermal/thermal_core.c
+++ b/drivers/thermal/thermal_core.c
@@ -2720,7 +2720,7 @@ thermal_boost_store(struct device *dev,
 				      struct device_attribute *attr, const char *buf, size_t len)
 {
 	int ret;
-	ret = snprintf(boost_buf, PAGE_SIZE, buf);
+	ret = snprintf(boost_buf, sizeof(boost_buf), buf);
 	return len;
 }
 


### PR DESCRIPTION
Issue in question:
`../drivers/input/touchscreen/focaltech_touch/focaltech_ex_fun.c:861:2: error: 'snprintf' size argument is too large; destination buffer has size 128, but size argument is 4096 [-Werror,-Wfortify-source]`
`        snprintf(fwname, PAGE_SIZE, "%s", buf);`